### PR TITLE
dont need lifecyclehook for privacy

### DIFF
--- a/client/src/components/toggle/Toggle.jsx
+++ b/client/src/components/toggle/Toggle.jsx
@@ -1,9 +1,9 @@
-import React, { useRef, useEffect } from "react";
+import React from "react";
 import { Container } from "./Toggle.styles";
 import { getToken } from "../../helpers/getToken";
 
 const fetchUpdatePrivacy = async (query) => {
-  const res = await fetch(`/api/matchup/private${query}`, {
+  return fetch(`/api/matchup/private${query}`, {
     method: "PUT",
     headers: {
       Accept: "application/json",
@@ -12,34 +12,28 @@ const fetchUpdatePrivacy = async (query) => {
     },
     credentials: "include",
   });
-  return res.json();
 };
 
 const Toggle = ({ lane, champion_id, opponent_id, privacy, setPrivacy }) => {
-  const initialLoad = useRef(true);
-
-  useEffect(() => {
-    if (initialLoad.current) {
-      initialLoad.current = false;
-      return;
-    }
-
+  const handleClick = (value) => {
     fetchUpdatePrivacy(
-      `?lane=${lane}&champion_id=${champion_id}&opponent_id=${opponent_id}&private=${privacy}`
-    ).catch((err) => console.error(err));
-  }, [privacy, lane, champion_id, opponent_id]);
+      `?lane=${lane}&champion_id=${champion_id}&opponent_id=${opponent_id}&private=${value}`
+    )
+      .then(() => setPrivacy(value))
+      .catch((err) => console.error(err));
+  };
 
   return (
     <Container>
       <Container.Option
         selected={privacy === true}
-        onClick={() => setPrivacy(true)}
+        onClick={() => handleClick(true)}
       >
         Private
       </Container.Option>
       <Container.Option
         selected={privacy === false}
-        onClick={() => setPrivacy(false)}
+        onClick={() => handleClick(false)}
       >
         Public
       </Container.Option>


### PR DESCRIPTION
Closes #71 

There's an edge case where it might fail in the future when someone changes the privacy settings of a dex page other than their current live match. 